### PR TITLE
Add text sharing functions

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,17 +29,19 @@ If you do not set a default or wish to update your active device for the session
 
 * Usage
 After selecting an active device, the following functions are available.
-| Function                        | Description                                                    |
-|---------------------------------+----------------------------------------------------------------|
-| kdeconnect-get-active-device    | Display the active device                                      |
-| kdeconnect-list-devices         | Display all visible devices, even unavailable ones             |
-| kdeconnect-ping                 | Send a notification to the active device                       |
-| kdeconnect-ping-msg             | Send a notification with a custom message to the active device |
-| kdeconnect-refresh              | Scan the network and refresh any available connections         |
-| kdeconnect-ring                 | Make the active device ring (useful for finding it)            |
-| kdeconnect-select-active-device | Select the active device from =kdeconnect-devices=             |
-| kdeconnect-send-file            | Send the selected file to the active device                    |
-| kdeconnect-send-sms             | Send an SMS to the specified destination                       |
+| Function                              | Description                                                    |
+|---------------------------------------+----------------------------------------------------------------|
+| kdeconnect-get-active-device          | Display the active device                                      |
+| kdeconnect-list-devices               | Display all visible devices, even unavailable ones             |
+| kdeconnect-ping                       | Send a notification to the active device                       |
+| kdeconnect-ping-msg                   | Send a notification with a custom message to the active device |
+| kdeconnect-refresh                    | Scan the network and refresh any available connections         |
+| kdeconnect-ring                       | Make the active device ring (useful for finding it)            |
+| kdeconnect-select-active-device       | Select the active device from =kdeconnect-devices=             |
+| kdeconnect-send-file                  | Send the selected file to the active device                    |
+| kdeconnect-send-text                  | Send text to the active device                                 |
+| kdeconnect-send-text-region-or-prompt | Interactively send text from region if relevant, or prompt     |
+| kdeconnect-send-sms                   | Send an SMS to the specified destination                       |
 
 * Troubleshooting
 If you're not seeing any response from your desired device, make sure there is an active connection.

--- a/README.org
+++ b/README.org
@@ -40,7 +40,7 @@ After selecting an active device, the following functions are available.
 | kdeconnect-select-active-device       | Select the active device from =kdeconnect-devices=             |
 | kdeconnect-send-file                  | Send the selected file to the active device                    |
 | kdeconnect-send-text                  | Send text to the active device                                 |
-| kdeconnect-send-text-region-or-prompt | Interactively send text from region if relevant, or prompt     |
+| kdeconnect-send-text-region-or-prompt | Interactively send text from active region, or prompt          |
 | kdeconnect-send-sms                   | Send an SMS to the specified destination                       |
 
 * Troubleshooting

--- a/kdeconnect.el
+++ b/kdeconnect.el
@@ -96,6 +96,25 @@
                                (expand-file-name path))) " ")))
 
 ;;;###autoload
+(defun kdeconnect-send-text (text)
+  "Send TEXT to the active device."
+  (interactive "MEnter a text to share: ")
+  (shell-command
+   (mapconcat 'identity
+              (list "kdeconnect-cli" "-d"
+                    (shell-quote-argument kdeconnect-active-device)
+                    "--share-text" (shell-quote-argument text)) " ")))
+
+;;;###autoload
+(defun kdeconnect-send-text-region-or-prompt ()
+  "Send text to the active device interactively.
+If the REGION is active send that text, otherwise prompt for what to send"
+  (interactive )
+  (if (use-region-p)
+      (kdeconnect-send-text (buffer-substring (region-beginning) (region-end)))
+    (call-interactively 'kdeconnect-send-text)))
+
+;;;###autoload
 (defun kdeconnect-select-active-device (name)
   "Set the active device to NAME."
   (interactive


### PR DESCRIPTION
I found the clipboard sharing to thrash both my computer and cell clipboards with contents I didn't need, so explicitly using `--share-text` seemed like a good idea. I hope this contribution fits with your elegant package here!