### PR TITLE
Device names in KDEConnect.

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,7 @@ Before calling any functions that interact with a specific device, you /must/ se
 There are two ways to do this.
 You can set a default device by adding
 #+BEGIN_SRC emacs-lisp
-(setq kdeconnect-active-device "<device ID>")
+(setq kdeconnect-active-device '("<name>" . "<device ID>"))
 #+END_SRC
 to your =init.el= file.
 When you load Emacs and call a function like kdeconnect-ping, that device will be the target.

--- a/README.org
+++ b/README.org
@@ -11,10 +11,12 @@ Pair your devices from these applications.
 
 Install the Emacs package (available in [[https://melpa.org/][MELPA]]) and add =(require 'kdeconnect)= to your =init.el= file.
 You will need to add the IDs of any devices you wish to use.
-If you don't already know these, call =M-x kdeconnect-list-devices= and check your =*Messages*= buffer.
-Set =kdeconnect-devices= in your =init.el= to be the IDs of your device(s) separated by commas, like so:
+If you don't already know these, call =M-x kdeconnect-list-devices= and check your =*Messages*= buffer or use =M-x kdeconnect-update-kdeconnect-devices= to fill the list with new devices.
+Set =kdeconnect-devices= in your =init.el= to be the NAME and IDs of your device(s), like so:
 #+BEGIN_SRC emacs-lisp
-(setq kdeconnect-devices "ef72819a8db1e193,ff172817910b1bc5,_2cd7dfcd_7260_22dd_6658_9aa2760b8275_")
+  (setq kdeconnect-devices '(("My cellphone" . "ef72819a8db1e193")
+                             ("My tablet" . "ff172817910b1bc5")
+                             ("My car" . "_2cd7dfcd_7260_22dd_6658_9aa2760b8275_")))
 #+END_SRC
 
 Before calling any functions that interact with a specific device, you /must/ set the active device, even if you only have one device ID in =kdeconnect-devices=.
@@ -29,19 +31,20 @@ If you do not set a default or wish to update your active device for the session
 
 * Usage
 After selecting an active device, the following functions are available.
-| Function                              | Description                                                    |
-|---------------------------------------+----------------------------------------------------------------|
-| kdeconnect-get-active-device          | Display the active device                                      |
-| kdeconnect-list-devices               | Display all visible devices, even unavailable ones             |
-| kdeconnect-ping                       | Send a notification to the active device                       |
-| kdeconnect-ping-msg                   | Send a notification with a custom message to the active device |
-| kdeconnect-refresh                    | Scan the network and refresh any available connections         |
-| kdeconnect-ring                       | Make the active device ring (useful for finding it)            |
-| kdeconnect-select-active-device       | Select the active device from =kdeconnect-devices=             |
-| kdeconnect-send-file                  | Send the selected file to the active device                    |
-| kdeconnect-send-text                  | Send text to the active device                                 |
-| kdeconnect-send-text-region-or-prompt | Interactively send text from active region, or prompt          |
-| kdeconnect-send-sms                   | Send an SMS to the specified destination                       |
+| Function                              | Description                                                     |
+|---------------------------------------+-----------------------------------------------------------------|
+| kdeconnect-update-kdeconnect-devices  | Update the list stored in =kdeconnect-devices= with new devices |
+| kdeconnect-get-active-device          | Display the active device                                       |
+| kdeconnect-list-devices               | Display all visible devices, even unavailable ones              |
+| kdeconnect-ping                       | Send a notification to the active device                        |
+| kdeconnect-ping-msg                   | Send a notification with a custom message to the active device  |
+| kdeconnect-refresh                    | Scan the network and refresh any available connections          |
+| kdeconnect-ring                       | Make the active device ring (useful for finding it)             |
+| kdeconnect-select-active-device       | Select the active device from =kdeconnect-devices=              |
+| kdeconnect-send-file                  | Send the selected file to the active device                     |
+| kdeconnect-send-text                  | Send text to the active device                                  |
+| kdeconnect-send-text-region-or-prompt | Interactively send text from active region, or prompt           |
+| kdeconnect-send-sms                   | Send an SMS to the specified destination                        |
 
 * Troubleshooting
 If you're not seeing any response from your desired device, make sure there is an active connection.

--- a/kdeconnect.el
+++ b/kdeconnect.el
@@ -196,14 +196,25 @@ If the REGION is active send that text, otherwise prompt for what to send"
         (kdeconnect-send-text (buffer-substring (region-beginning) (region-end)))
       (call-interactively 'kdeconnect-send-text))))
 
+(defun kdeconnect--update-devices-maybe ()
+  "Update `kdeconnect-devices' if no devices is present in the list."
+  (when (seq-empty-p kdeconnect-devices)
+    (message "No devices in kdeconnect-devices list. Updating devices...")
+    (kdeconnect-update-kdeconnect-devices)))
+
 ;;;###autoload
 (defun kdeconnect-select-active-device (name)
-  "Set the active device to NAME."
+  "Set the active device to NAME.
+If no devices are in `kdeconnect-devices' list, call
+`kdeconnect-update-kdeconnect-devices' to update the list of possible
+new devices to select."
   (interactive
-   (list (completing-read
-          "Select a device: "
-          (map-keys kdeconnect-devices)
-          nil t "")))
+   (list (progn
+           (kdeconnect--update-devices-maybe)
+           (completing-read
+            "Select a device: "
+            (map-keys kdeconnect-devices)
+            nil t ""))))
   (setq kdeconnect-active-device
         (assoc name kdeconnect-devices #'string=)))
 

--- a/kdeconnect.el
+++ b/kdeconnect.el
@@ -36,7 +36,7 @@
 (require 'seq)
 
 (defgroup kdeconnect nil
-  "KDEConnect integration"
+  "KDEConnect integration."
   :tag "KDEConnect"
   :group 'convenience
   :link '(url-link "https://github.com/carldotac/kdeconnect.el"))
@@ -67,7 +67,7 @@ one."
    ((= (length kdeconnect-devices) 0)
     (message "No devices! Use M-x kdeconnect-update-kdeconnect-devices.")
     nil)
-   ((y-or-n-p (format "No active device selected. Use %s?"
+   ((y-or-n-p (format "No active device selected.  Use %s?"
                       (caar kdeconnect-devices)))
     (setq kdeconnect-active-device (car kdeconnect-devices))
     kdeconnect-active-device)

--- a/kdeconnect.el
+++ b/kdeconnect.el
@@ -1,10 +1,12 @@
-;;; kdeconnect.el --- An interface for KDE Connect
+;;; kdeconnect.el --- An interface for KDE Connect  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2016-2020 Carl Lieberman
 
 ;; Author: Carl Lieberman <dev@carl.ac>
-;; Keywords: kdeconnect, android
+;; Keywords: convenience
 ;; Version: 1.2.2
+;; URL: https://github.com/carldotac/kdeconnect.el
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -31,6 +33,7 @@
 ;;; Code:
 
 (require 'map)
+(require 'seq)
 
 (defvar kdeconnect-active-device nil
   "The (NAME . ID) of the active device.")
@@ -56,6 +59,7 @@ The string must be composed of lines with \"ID NAME\" format."
             (cons (match-string 2 line) (match-string 1 line)))
           (split-string output-string "\n" t)))
 
+;;;###autoload
 (defun kdeconnect-update-kdeconnect-devices ()
   "Update `kdeconnec-devices' with the current list.
 If the a device ID is already present, do not add it."
@@ -163,6 +167,9 @@ If the REGION is active send that text, otherwise prompt for what to send"
 
 ;;;###autoload
 (defun kdeconnect-send-sms (message destination)
+  "Send an SMS message through your cellphone.
+MESSAGE is a string with the message to send.  DESTINATION is a
+number to send (it must be a number value, not string)."
   (interactive "MEnter message: \nnEnter destination: ")
   (shell-command
    (mapconcat 'identity

--- a/kdeconnect.el
+++ b/kdeconnect.el
@@ -57,6 +57,21 @@ It can be modified with `setq' or customized."
   :type '(alist :key-type string :value-type string)
   :group 'kdeconnect)
 
+(defun kdeconnect--ensure-active-device ()
+  "Make sure there is an active device, ask user otherwise.
+Signal error if there is no active device and the user has not selected
+one."
+  (cond
+   (kdeconnect-active-device
+      kdeconnect-active-device)
+   ((y-or-n-p (format "No active device selected. Use %s?"
+                      (caar kdeconnect-devices)))
+    (setq kdeconnect-active-device (car kdeconnect-devices))
+    kdeconnect-active-device)
+   (t
+    (message "No active device. Use M-x kdeconnect-select-active-device.")
+    nil)))
+
 (defun kdeconnect--new-devices (device-list)
   "Return new devices IDs not in the `kdeconnect-devices' variable.
 DEVICE-LIST is an alist with (NAME . ID) elements."
@@ -110,21 +125,23 @@ adding a `setq' sentence on your init file."
 (defun kdeconnect-ping ()
   "Ping the active device."
   (interactive)
-  (shell-command
-   (mapconcat 'identity
-              (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument (cdr kdeconnect-active-device))
-                    "--ping") " ")))
+  (when (kdeconnect--ensure-active-device)
+    (shell-command
+     (mapconcat 'identity
+                (list "kdeconnect-cli" "-d"
+                      (shell-quote-argument (cdr kdeconnect-active-device))
+                      "--ping") " "))))
 
 ;;;###autoload
 (defun kdeconnect-ping-msg (message)
   "Ping the active device with MESSAGE."
   (interactive "MEnter message: ")
-  (shell-command
-   (mapconcat 'identity
-              (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument (cdr kdeconnect-active-device))
-                    "--ping-msg" (shell-quote-argument message)) " ")))
+  (when (kdeconnect--ensure-active-device)
+    (shell-command
+     (mapconcat 'identity
+                (list "kdeconnect-cli" "-d"
+                      (shell-quote-argument (cdr kdeconnect-active-device))
+                      "--ping-msg" (shell-quote-argument message)) " "))))
 
 ;;;###autoload
 (defun kdeconnect-refresh ()
@@ -136,41 +153,45 @@ adding a `setq' sentence on your init file."
 (defun kdeconnect-ring ()
   "Ring the active device."
   (interactive)
-  (shell-command
-   (mapconcat 'identity
-              (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument (cdr kdeconnect-active-device))
-                    "--ring") " ")))
+  (when (kdeconnect--ensure-active-device)
+    (shell-command
+     (mapconcat 'identity
+                (list "kdeconnect-cli" "-d"
+                      (shell-quote-argument (cdr kdeconnect-active-device))
+                      "--ring") " "))))
 
 ;;;###autoload
 (defun kdeconnect-send-file (path)
   "Send the file at PATH to the active device."
   (interactive "fSelect file: ")
-  (shell-command
-   (mapconcat 'identity
-              (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument (cdr kdeconnect-active-device))
-                    "--share" (shell-quote-argument
-                               (expand-file-name path))) " ")))
+  (when (kdeconnect--ensure-active-device)
+    (shell-command
+     (mapconcat 'identity
+                (list "kdeconnect-cli" "-d"
+                      (shell-quote-argument (cdr kdeconnect-active-device))
+                      "--share" (shell-quote-argument
+                                (expand-file-name path))) " "))))
 
 ;;;###autoload
 (defun kdeconnect-send-text (text)
   "Send TEXT to the active device."
   (interactive "MEnter a text to share: ")
-  (shell-command
-   (mapconcat 'identity
-              (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument (cdr kdeconnect-active-device))
-                    "--share-text" (shell-quote-argument text)) " ")))
+  (when (kdeconnect--ensure-active-device)
+    (shell-command
+     (mapconcat 'identity
+                (list "kdeconnect-cli" "-d"
+                      (shell-quote-argument (cdr kdeconnect-active-device))
+                      "--share-text" (shell-quote-argument text)) " "))))
 
 ;;;###autoload
 (defun kdeconnect-send-text-region-or-prompt ()
   "Send text to the active device interactively.
 If the REGION is active send that text, otherwise prompt for what to send"
   (interactive )
-  (if (use-region-p)
-      (kdeconnect-send-text (buffer-substring (region-beginning) (region-end)))
-    (call-interactively 'kdeconnect-send-text)))
+  (when (kdeconnect--ensure-active-device)
+    (if (use-region-p)
+        (kdeconnect-send-text (buffer-substring (region-beginning) (region-end)))
+      (call-interactively 'kdeconnect-send-text))))
 
 ;;;###autoload
 (defun kdeconnect-select-active-device (name)
@@ -189,12 +210,13 @@ If the REGION is active send that text, otherwise prompt for what to send"
 MESSAGE is a string with the message to send.  DESTINATION is a
 number to send (it must be a number value, not string)."
   (interactive "MEnter message: \nnEnter destination: ")
-  (shell-command
-   (mapconcat 'identity
-              (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument (cdr kdeconnect-active-device))
-                    "--destination" (number-to-string destination)
-                    "--send-sms" (shell-quote-argument message)) " ")))
+  (when (kdeconnect--ensure-active-device)
+    (shell-command
+     (mapconcat 'identity
+                (list "kdeconnect-cli" "-d"
+                      (shell-quote-argument (cdr kdeconnect-active-device))
+                      "--destination" (number-to-string destination)
+                      "--send-sms" (shell-quote-argument message)) " "))))
 
 (provide 'kdeconnect)
 ;;; kdeconnect.el ends here

--- a/kdeconnect.el
+++ b/kdeconnect.el
@@ -33,7 +33,7 @@
 (require 'map)
 
 (defvar kdeconnect-active-device nil
-  "The ID of the active device.")
+  "The (NAME . ID) of the active device.")
 
 (defvar kdeconnect-devices nil
   "The IDs of your available devices.
@@ -72,7 +72,11 @@ If the a device ID is already present, do not add it."
 (defun kdeconnect-get-active-device ()
   "Display the ID of the active device."
   (interactive)
-  (message kdeconnect-active-device))
+  (if kdeconnect-active-device
+      (message "Active device: %s (ID: %s)"
+               (car kdeconnect-active-device)
+               (cdr kdeconnect-active-device))
+    (message "No active device. Use M-x kdeconnect-select-active-device")))
 
 ;;;###autoload
 (defun kdeconnect-list-devices ()
@@ -87,7 +91,7 @@ If the a device ID is already present, do not add it."
   (shell-command
    (mapconcat 'identity
               (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument kdeconnect-active-device)
+                    (shell-quote-argument (cdr kdeconnect-active-device))
                     "--ping") " ")))
 
 ;;;###autoload
@@ -97,7 +101,7 @@ If the a device ID is already present, do not add it."
   (shell-command
    (mapconcat 'identity
               (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument kdeconnect-active-device)
+                    (shell-quote-argument (cdr kdeconnect-active-device))
                     "--ping-msg" (shell-quote-argument message)) " ")))
 
 ;;;###autoload
@@ -113,7 +117,7 @@ If the a device ID is already present, do not add it."
   (shell-command
    (mapconcat 'identity
               (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument kdeconnect-active-device)
+                    (shell-quote-argument (cdr kdeconnect-active-device))
                     "--ring") " ")))
 
 ;;;###autoload
@@ -123,7 +127,7 @@ If the a device ID is already present, do not add it."
   (shell-command
    (mapconcat 'identity
               (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument kdeconnect-active-device)
+                    (shell-quote-argument (cdr kdeconnect-active-device))
                     "--share" (shell-quote-argument
                                (expand-file-name path))) " ")))
 
@@ -134,7 +138,7 @@ If the a device ID is already present, do not add it."
   (shell-command
    (mapconcat 'identity
               (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument kdeconnect-active-device)
+                    (shell-quote-argument (cdr kdeconnect-active-device))
                     "--share-text" (shell-quote-argument text)) " ")))
 
 ;;;###autoload
@@ -155,7 +159,7 @@ If the REGION is active send that text, otherwise prompt for what to send"
           (map-keys kdeconnect-devices)
           nil t "")))
   (setq kdeconnect-active-device
-        (alist-get name kdeconnect-devices nil nil #'string=)))
+        (assoc name kdeconnect-devices #'string=)))
 
 ;;;###autoload
 (defun kdeconnect-send-sms (message destination)
@@ -163,7 +167,7 @@ If the REGION is active send that text, otherwise prompt for what to send"
   (shell-command
    (mapconcat 'identity
               (list "kdeconnect-cli" "-d"
-                    (shell-quote-argument kdeconnect-active-device)
+                    (shell-quote-argument (cdr kdeconnect-active-device))
                     "--destination" (number-to-string destination)
                     "--send-sms" (shell-quote-argument message)) " ")))
 

--- a/kdeconnect.el
+++ b/kdeconnect.el
@@ -202,7 +202,10 @@ If the REGION is active send that text, otherwise prompt for what to send"
   (interactive
    (list (completing-read
           "Select a device: "
-          (map-keys kdeconnect-devices)
+          (map-keys (progn (unless kdeconnect-devices
+                             (message "No devices found... updating paired devices...")
+                             (kdeconnect-update-kdeconnect-devices))
+                           kdeconnect-devices))
           nil t "")))
   (setq kdeconnect-active-device
         (assoc name kdeconnect-devices #'string=)))

--- a/kdeconnect.el
+++ b/kdeconnect.el
@@ -63,7 +63,10 @@ Signal error if there is no active device and the user has not selected
 one."
   (cond
    (kdeconnect-active-device
-      kdeconnect-active-device)
+    kdeconnect-active-device)
+   ((= (length kdeconnect-devices) 0)
+    (message "No devices! Use M-x kdeconnect-update-kdeconnect-devices.")
+    nil)
    ((y-or-n-p (format "No active device selected. Use %s?"
                       (caar kdeconnect-devices)))
     (setq kdeconnect-active-device (car kdeconnect-devices))

--- a/kdeconnect.el
+++ b/kdeconnect.el
@@ -35,12 +35,27 @@
 (require 'map)
 (require 'seq)
 
-(defvar kdeconnect-active-device nil
-  "The (NAME . ID) of the active device.")
+(defgroup kdeconnect nil
+  "KDEConnect integration"
+  :tag "KDEConnect"
+  :group 'convenience
+  :link '(url-link "https://github.com/carldotac/kdeconnect.el"))
 
-(defvar kdeconnect-devices nil
+(defcustom kdeconnect-active-device nil
+  "The (NAME . ID) of the active device.
+This variable can be setted by `kdeconnect-select-active-device',
+`setq' or the customization buffer."
+  :type '(cons string string)
+  :group 'kdeconnect)
+
+(defcustom kdeconnect-devices nil
   "The IDs of your available devices.
-An alist of (name . ID) of available devices.")
+An alist of (name . ID) of available devices.  This variable can be
+updated with new devices with `kdeconnect-update-kdeconnect-devices'
+for the current session only.
+It can be modified with `setq' or customized."
+  :type '(alist :key-type string :value-type string)
+  :group 'kdeconnect)
 
 (defun kdeconnect--new-devices (device-list)
   "Return new devices IDs not in the `kdeconnect-devices' variable.
@@ -61,8 +76,11 @@ The string must be composed of lines with \"ID NAME\" format."
 
 ;;;###autoload
 (defun kdeconnect-update-kdeconnect-devices ()
-  "Update `kdeconnec-devices' with the current list.
-If the a device ID is already present, do not add it."
+  "Update `kdeconnect-devices' with the current list.
+If the a device ID is already present, do not add it.
+The update will affect to the curent Emacs session only.  The
+`kdeconnect-devices' variable must be saved by customizing it or
+adding a `setq' sentence on your init file."
   (interactive)
   (let ((new-devices (kdeconnect--new-devices
                       (kdeconnect--parse-device-list


### PR DESCRIPTION
Hi! 👋🏽 

I added several features to kdeconnect.el, mostly focused on using device names and not IDs.

- kdeconnect-devices can store device names and IDs.
- A `M-x kdeconnect-update-kdeconnect-devices` to discover devices and IDs.
- A customization group "kdeconnect". Added customization option for kdeconnect-devices.
- Selecting a device by its name and not its ID (which is easier to remember!).
- Readme updated to add the new interactive function and to explain the kdeconnect-devices new structure (an alist).
- Checkdock and flycheck are happy 😄 

Hope this is useful!
Cheers!